### PR TITLE
Generic default series and coseries

### DIFF
--- a/smallcheck.cabal
+++ b/smallcheck.cabal
@@ -47,4 +47,4 @@ Library
 
     if impl(ghc >= 7.2.1)
       cpp-options: -DGENERICS
-      build-depends: ghc-prim >= 0.2
+      build-depends: ghc-prim >= 0.2, dlist >= 0.2 && < 0.6


### PR DESCRIPTION
Hi Roman,

Attached is a patch for `smallcheck` which adds generic default implementations for the `series` and `coseries` methods of `Serial`. It uses the new [GHC Generics](http://www.haskell.org/ghc/docs/latest/html/users_guide/generic-programming.html) feature.

With this patch a user doesn't have to write his own `Serial` instance:

```
{-# LANGUAGE DeriveGeneric #-}

import Test.SmallCheck
import GHC.Generics

data Tree a = Null | Fork (Tree a) a (Tree a) deriving (Show, Generic)

instance (Serial a) => Serial (Tree a)
```

For example:

```
> (series :: Series (Tree ())) 0
[]
> (series :: Series (Tree ())) 1
[Null]
> (series :: Series (Tree ())) 2
[Null,Fork Null () Null]
> (series :: Series (Tree ())) 3
[Null,Fork Null () Null,Fork Null () (Fork Null () Null),Fork (Fork Null () Null) () Null,Fork (Fork Null () Null) () (Fork Null () Null)]
```

I didn't yet test this the generic `coseries` thoroughly but I think it should work.

Regards,

Bas
