### PR TITLE
Addition of `Serial`/`CoSerial` instances `Int*` and `Word*`

### DIFF
--- a/src/Test/SmallCheck/Series.hs
+++ b/src/Test/SmallCheck/Series.hs
@@ -511,26 +511,26 @@ coInts rs =
       | otherwise -> Nothing
     }
 
-instance Monad m => Serial m Word where series = positives
-instance Monad m => CoSerial m Word where coseriesP = coPositives
+instance Monad m => Serial m Word where series = nonNegatives
+instance Monad m => CoSerial m Word where coseriesP = coNonNegatives
 
-instance Monad m => Serial m Word8 where series = positives
-instance Monad m => CoSerial m Word8 where coseriesP = coPositives
+instance Monad m => Serial m Word8 where series = nonNegatives
+instance Monad m => CoSerial m Word8 where coseriesP = coNonNegatives
 
-instance Monad m => Serial m Word16 where series = positives
-instance Monad m => CoSerial m Word16 where coseriesP = coPositives
+instance Monad m => Serial m Word16 where series = nonNegatives
+instance Monad m => CoSerial m Word16 where coseriesP = coNonNegatives
 
-instance Monad m => Serial m Word32 where series = positives
-instance Monad m => CoSerial m Word32 where coseriesP = coPositives
+instance Monad m => Serial m Word32 where series = nonNegatives
+instance Monad m => CoSerial m Word32 where coseriesP = coNonNegatives
 
-instance Monad m => Serial m Word64 where series = positives
-instance Monad m => CoSerial m Word64 where coseriesP = coPositives
+instance Monad m => Serial m Word64 where series = nonNegatives
+instance Monad m => CoSerial m Word64 where coseriesP = coNonNegatives
 
-positives :: (Monad m, Integral n, Bounded n) => Series m n
-positives = generate $ \d -> take (d+1) [0..maxBound]
+nonNegatives :: (Monad m, Integral n, Bounded n) => Series m n
+nonNegatives = generate $ \d -> take (d+1) [0..maxBound]
 
-coPositives :: (Monad m, Integral n) => Series m b -> Series m (n -> Maybe b)
-coPositives rs =
+coNonNegatives :: (Monad m, Integral n) => Series m b -> Series m (n -> Maybe b)
+coNonNegatives rs =
     -- This is a recursive function, because @alts1 rs@ typically calls
     -- back to 'coseries' (but with lower depth).
     --

--- a/src/Test/SmallCheck/Series.hs
+++ b/src/Test/SmallCheck/Series.hs
@@ -686,7 +686,7 @@ instance (Serial m a, CoSerial m a, Serial m b, CoSerial m b) => CoSerial m (a->
 instance (Serial Identity a, Show a, Show b) => Show (a:->b) where
   show Fun { function = f, functionDepth = depthLimit, functionDefault = mbDef } =
     if maxarheight == 1
-    && sumarwidth + length ars * length "->;" < widthLimit then
+    && sumarwidth + length ars * length ("->;"::String) < widthLimit then
       "{"++(
       concat $ intersperse ";" $ [a++"->"++r | (a,r) <- ars]
       )++"}"

--- a/src/Test/SmallCheck/Series.hs
+++ b/src/Test/SmallCheck/Series.hs
@@ -497,7 +497,7 @@ ints :: (Monad m, Integral n, Bounded n) => Series m n
 ints = generate (\d -> if d >= 0 then pure 0 else empty) <|>
     nats `interleave` (fmap negate nats)
   where
-    nats = generate $ \d -> take (d+1) [1..maxBound]
+    nats = generate $ \d -> take d [1..maxBound]
 
 -- TODO check this
 -- | Helper function to create 'Int' 'CoSerial' instances.

--- a/src/Test/SmallCheck/Series.hs
+++ b/src/Test/SmallCheck/Series.hs
@@ -187,6 +187,7 @@ import Control.Monad.Logic
 import Control.Monad.Reader
 import Control.Applicative
 import Control.Monad.Identity
+import Data.Int
 import Data.List
 import Data.Ratio
 import Data.Maybe
@@ -475,16 +476,30 @@ instance Monad m => Serial m () where
 instance Monad m => CoSerial m () where
   coseriesP rs = const <$> alts0 rs
 
-instance Monad m => Serial m Int where
-  series =
-    generate (\d -> if d >= 0 then pure 0 else empty) <|>
-      nats `interleave` (fmap negate nats)
-    where
-      nats = generate $ \d -> take (d+1) [1..maxBound]
+instance Monad m => Serial m Int where series = ints
+instance Monad m => CoSerial m Int where coseriesP = coInts
+
+instance Monad m => Serial m Int8 where series = ints
+instance Monad m => CoSerial m Int8 where coseriesP = coInts
+
+instance Monad m => Serial m Int16 where series = ints
+instance Monad m => CoSerial m Int16 where coseriesP = coInts
+
+instance Monad m => Serial m Int32 where series = ints
+instance Monad m => CoSerial m Int32 where coseriesP = coInts
+
+instance Monad m => Serial m Int64 where series = ints
+instance Monad m => CoSerial m Int64 where coseriesP = coInts
+
+ints :: (Monad m, Integral n, Bounded n) => Series m n
+ints = generate (\d -> if d >= 0 then pure 0 else empty) <|>
+    nats `interleave` (fmap negate nats)
+  where
+    nats = generate $ \d -> take (d+1) [1..maxBound]
 
 -- TODO check this
-instance Monad m => CoSerial m Int where
-  coseriesP rs =
+coInts :: (Monad m, Integral n) => Series m b -> Series m (n -> Maybe b)
+coInts rs =
     alts0 rs >>- \z ->
     alts1 rs >>- \f ->
     alts1 rs >>- \g ->

--- a/src/Test/SmallCheck/Series.hs
+++ b/src/Test/SmallCheck/Series.hs
@@ -492,6 +492,7 @@ instance Monad m => CoSerial m Int32 where coseriesP = coInts
 instance Monad m => Serial m Int64 where series = ints
 instance Monad m => CoSerial m Int64 where coseriesP = coInts
 
+-- | Helper function to create 'Int' 'Serial' instances.
 ints :: (Monad m, Integral n, Bounded n) => Series m n
 ints = generate (\d -> if d >= 0 then pure 0 else empty) <|>
     nats `interleave` (fmap negate nats)
@@ -499,6 +500,7 @@ ints = generate (\d -> if d >= 0 then pure 0 else empty) <|>
     nats = generate $ \d -> take (d+1) [1..maxBound]
 
 -- TODO check this
+-- | Helper function to create 'Int' 'CoSerial' instances.
 coInts :: (Monad m, Integral n) => Series m b -> Series m (n -> Maybe b)
 coInts rs =
     alts0 rs >>- \z ->
@@ -526,9 +528,11 @@ instance Monad m => CoSerial m Word32 where coseriesP = coNonNegatives
 instance Monad m => Serial m Word64 where series = nonNegatives
 instance Monad m => CoSerial m Word64 where coseriesP = coNonNegatives
 
+-- | Helper function to create 'Word' 'Serial' instances.
 nonNegatives :: (Monad m, Integral n, Bounded n) => Series m n
 nonNegatives = generate $ \d -> take (d+1) [0..maxBound]
 
+-- | Helper function to create 'Word' 'CoSerial' instances.
 coNonNegatives :: (Monad m, Integral n) => Series m b -> Series m (n -> Maybe b)
 coNonNegatives rs =
     -- This is a recursive function, because @alts1 rs@ typically calls

--- a/src/Test/SmallCheck/Series.hs
+++ b/src/Test/SmallCheck/Series.hs
@@ -480,7 +480,7 @@ instance Monad m => Serial m Int where
     generate (\d -> if d >= 0 then pure 0 else empty) <|>
       nats `interleave` (fmap negate nats)
     where
-      nats = generate $ \d -> [1..d]
+      nats = generate $ \d -> take (d+1) [1..maxBound]
 
 -- TODO check this
 instance Monad m => CoSerial m Int where


### PR DESCRIPTION
Notice that now the previous `Int` `Serial` instance stops generating when
depth is `maxBound`. This was useful for 8bits words/ints so I reused it for
all sizes.

I thought I could get rid of `N` wrapper, but it turns out to still be useful.
It's more cumbersome to convert Integrals to `Word`s for the same
functionality.

Closes #30