### PR TITLE
instance (Serial, CoSerial) m (Word, Natural)

### DIFF
--- a/Test/SmallCheck/Series.hs
+++ b/Test/SmallCheck/Series.hs
@@ -189,6 +189,8 @@ import Control.Applicative
 import Control.Monad.Identity
 import Data.List
 import Data.Ratio
+import Data.Word (Word)
+import Numeric.Natural (Natural)
 import Test.SmallCheck.SeriesMonad
 import GHC.Generics
 
@@ -484,6 +486,16 @@ instance Monad m => Serial m Integer where
   series = (toInteger :: Int -> Integer) <$> series
 instance Monad m => CoSerial m Integer where
   coseries rs = (. (fromInteger :: Integer->Int)) <$> coseries rs
+
+instance Monad m => Serial m Natural where
+  series = (fromIntegral :: N Int -> Natural) <$> series
+instance Monad m => CoSerial m Natural where
+  coseries rs = (. (fromIntegral :: Natural->Int)) <$> coseries rs
+
+instance Monad m => Serial m Word where
+  series = (fromIntegral :: N Int -> Word) <$> series
+instance Monad m => CoSerial m Word where
+  coseries rs = (. (fromIntegral :: Word->Int)) <$> coseries rs
 
 -- | 'N' is a wrapper for 'Integral' types that causes only non-negative values
 -- to be generated. Generated functions of type @N a -> b@ do not distinguish

--- a/test/test.hs
+++ b/test/test.hs
@@ -12,6 +12,8 @@ import Control.Monad.Identity
 import Data.Proxy
 import Data.List
 import qualified Data.Set as Set
+import Data.Word
+import Numeric.Natural
 
 ------------------------------
 -- Auxiliary definitions
@@ -60,6 +62,12 @@ instance SizeTest Int where
 instance SizeTest Integer where
   size _ d = max 0 $ 2*d+1
 
+instance SizeTest Word where
+  size _ d = max 0 $ 2*d+1
+
+instance SizeTest Natural where
+  size _ d = max 0 $ 2*d+1
+
 instance SizeTest a => SizeTest (Maybe a) where
   size _ d = if d > 0 then size (Proxy :: Proxy a) (d-1) + 1 else 0
 
@@ -78,6 +86,8 @@ types =
   , TestableType "Bool"       (Proxy :: Proxy Bool)
   , TestableType "Int"        (Proxy :: Proxy Int)
   , TestableType "Integer"    (Proxy :: Proxy Integer)
+  , TestableType "Word"       (Proxy :: Proxy Word)
+  , TestableType "Natural"    (Proxy :: Proxy Natural)
   , TestableType "Maybe Int"  (Proxy :: Proxy (Maybe Int))
   , TestableType "[Int]"      (Proxy :: Proxy [Int])
   ]


### PR DESCRIPTION
One could use `N` but it is convenient to not need to convert.
